### PR TITLE
Change 'meta-freescale' from yocto to github

### DIFF
--- a/ls-5.15.71-2.2.0.xml
+++ b/ls-5.15.71-2.2.0.xml
@@ -9,7 +9,7 @@
   <project name="freescale/meta-freescale-distro" path="sources/meta-freescale-distro" remote="github" revision="d5bbb487b2816dfc74984a78b67f7361ce404253" upstream="kirkstone"/>
   <project name="kraj/meta-clang" path="sources/meta-clang" remote="github" revision="c728c3f9168c8a4ed05163a51dd48ca1ad8ac21d" upstream="kirkstone"/>
   <project name="meta-cloud-services" path="sources/meta-cloud-services" remote="yocto" revision="12efde8056a004e8d3a337edb2728d05edbc383b" upstream="kirkstone"/>
-  <project name="meta-freescale" path="sources/meta-freescale" remote="yocto" revision="c82d4634e7aba8bc0de73ce1dfc997b630051571" upstream="kirkstone"/>
+  <project name="meta-freescale" path="sources/meta-freescale" remote="github" revision="c82d4634e7aba8bc0de73ce1dfc997b630051571" upstream="kirkstone"/>
   <project name="meta-security" path="sources/meta-security" remote="yocto" revision="c79262a30bd385f5dbb009ef8704a1a01644528e" upstream="kirkstone"/>
   <project name="meta-selinux" path="sources/meta-selinux" remote="yocto" revision="a401f4b2816a0b41ce8d9351542658c721935bcd" upstream="kirkstone"/>
   <project name="meta-virtualization" path="sources/meta-virtualization" remote="yocto" revision="9482648daf0bb42ff3475e7892542cf99f3b8d48" upstream="kirkstone"/>


### PR DESCRIPTION
I believe [this](https://github.com/nxp-qoriq/yocto-sdk/blob/kirkstone/ls-5.15.71-2.2.0.xml#L12) is pointing to the wrong repo.
It should point out [here](https://github.com/Freescale/meta-freescale)